### PR TITLE
refactor: use promises instead of callbacks

### DIFF
--- a/features/generate_config.feature
+++ b/features/generate_config.feature
@@ -6,7 +6,11 @@ Feature: Generating config
 
   Scenario Outline: generate config
     When I run "dependency-lint --generate-config <EXT>"
-    Then now I have the file "dependency-lint.<EXT>" with the default config
+    Then I see the output
+      """
+      Configuration file generated at "dependency-lint.<EXT>"
+      """
+    And now I have the file "dependency-lint.<EXT>" with the default config
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/support/hooks.coffee
+++ b/features/support/hooks.coffee
@@ -1,23 +1,16 @@
-async = require 'async'
-{expect} = require 'chai'
-fsExtra = require 'fs-extra'
+{addToJsonFile} = require '../support/json_helpers'
 path = require 'path'
-tmp = require 'tmp'
+getTmpDir = require '../../spec/support/get_tmp_dir'
 
 
 module.exports = ->
 
-  @Before (done) ->
-    async.series [
-      (next) =>
-        tmp.dir {unsafeCleanup: yes}, (err, @tmpDir) => next err
-      (next) =>
-        fsExtra.writeJson path.join(@tmpDir, 'package.json'), {}, next
-    ], done
+  @Before ->
+    getTmpDir()
+      .save @, 'tmpDir'
+      .then => addToJsonFile path.join(@tmpDir, 'package.json'), {}
 
-
-  @After (done) ->
+  @After ->
     unless @errorExpected
       expect(@error).to.not.exist
       expect(@stderr).to.be.empty
-    done()

--- a/features/support/hooks.coffee
+++ b/features/support/hooks.coffee
@@ -7,8 +7,7 @@ module.exports = ->
 
   @Before ->
     getTmpDir()
-      .save @, 'tmpDir'
-      .then => addToJsonFile path.join(@tmpDir, 'package.json'), {}
+      .then (@tmpDir) => addToJsonFile path.join(@tmpDir, 'package.json'), {}
 
   @After ->
     unless @errorExpected

--- a/features/support/json_helpers.coffee
+++ b/features/support/json_helpers.coffee
@@ -1,13 +1,16 @@
 _ = require 'lodash'
-fs = require 'fs-extra'
+fsExtra = require 'fs-extra'
+Promise = require 'bluebird'
+
+readJson = Promise.promisify fsExtra.readJson
+outputJson = Promise.promisify fsExtra.outputJson
 
 
-addToJsonFile = (filePath, toAdd, done) ->
-  fs.readFile filePath, encoding: 'utf8', (err, data) ->
-    output = {}
-    _.assign(output, JSON.parse(data)) unless err
-    _.assign output, toAdd
-    fs.outputJson filePath, output, done
+addToJsonFile = (filePath, toAdd) ->
+  readJson filePath
+    .catch -> {}
+    .then (obj) -> _.assign obj, toAdd
+    .then (obj) -> outputJson filePath, obj
 
 
 module.exports = {addToJsonFile}

--- a/features/support/json_helpers.coffee
+++ b/features/support/json_helpers.coffee
@@ -2,13 +2,14 @@ _ = require 'lodash'
 fsExtra = require 'fs-extra'
 Promise = require 'bluebird'
 
-readJson = Promise.promisify fsExtra.readJson
+access = Promise.promisify require('fs').access
 outputJson = Promise.promisify fsExtra.outputJson
+readJson = Promise.promisify fsExtra.readJson
 
 
 addToJsonFile = (filePath, toAdd) ->
-  readJson filePath
-    .catch -> {}
+  access filePath
+    .then (-> readJson filePath), (-> {})
     .then (obj) -> _.assign obj, toAdd
     .then (obj) -> outputJson filePath, obj
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "tmp": "^0.0.26"
   },
   "dependencies": {
-    "async": "^1.0.0",
-    "async-handlers": "^1.2.1",
+    "bluebird": "^2.9.24",
     "coffee-script": "^1.9.0",
     "colors": "^1.0.3",
     "detective": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/charlierudolph/dependency-lint",
   "devDependencies": {
     "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
     "coffeelint": "^1.8.1",
     "cson-parser": "^1.1.1",
     "cucumber": "^0.5.0",

--- a/spec/spec_helper.coffee
+++ b/spec/spec_helper.coffee
@@ -1,8 +1,17 @@
 chai = require 'chai'
-sinon = require 'sinon'
 chai.use require 'sinon-chai'
+Promise = require 'bluebird'
+sinon = require 'sinon'
+
 
 global.expect = chai.expect
 global.sinon = sinon
 
-process.env.NODE_ENV = 'test'
+
+Promise::save = (context, saveThenAs, saveCatchAs) ->
+  result = @
+  if saveThenAs
+    result = result.then (arg) -> context[saveThenAs] = arg
+  if saveCatchAs
+    result = result.catch (arg) -> context[saveCatchAs] = arg
+  result

--- a/spec/spec_helper.coffee
+++ b/spec/spec_helper.coffee
@@ -1,17 +1,8 @@
 chai = require 'chai'
 chai.use require 'sinon-chai'
-Promise = require 'bluebird'
+chai.use require 'chai-as-promised'
 sinon = require 'sinon'
 
 
 global.expect = chai.expect
 global.sinon = sinon
-
-
-Promise::save = (context, saveThenAs, saveCatchAs) ->
-  result = @
-  if saveThenAs
-    result = result.then (arg) -> context[saveThenAs] = arg
-  if saveCatchAs
-    result = result.catch (arg) -> context[saveCatchAs] = arg
-  result

--- a/spec/support/get_tmp_dir.coffee
+++ b/spec/support/get_tmp_dir.coffee
@@ -1,0 +1,10 @@
+Promise = require 'bluebird'
+
+tmpDir = Promise.promisify require('tmp').dir
+
+
+getTmpDir = ->
+  tmpDir(unsafeCleanup: yes).spread (tmpDir) -> tmpDir
+
+
+module.exports = getTmpDir

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -24,7 +24,7 @@ generateConfig = ->
   destFilename = "dependency-lint.#{extension}"
   dest = path.join process.cwd(), destFilename
   copy src, dest
-    .then "Configuration file generated at \"#{destFilename}\""
+    .then -> console.log "Configuration file generated at \"#{destFilename}\""
     .catch exitOnError
 
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -1,8 +1,11 @@
-asyncHandlers = require 'async-handlers'
+_ = require 'lodash'
 {docopt} = require 'docopt'
-fs = require 'fs-extra'
-path = require 'path'
+exitOnError = require './util/exit_on_error'
 extensions = require './configuration_loader/supported_file_extensions'
+path = require 'path'
+Promise = require 'bluebird'
+
+copy = Promise.promisify require('fs-extra').copy
 
 
 options = docopt """
@@ -16,14 +19,13 @@ options = docopt """
 
 
 generateConfig = ->
-  break for extension in extensions when options[extension]
+  extension = _.find extensions, (ext) -> options[ext]
   src = path.join __dirname, '..', 'config', "default.#{extension}"
   destFilename = "dependency-lint.#{extension}"
   dest = path.join process.cwd(), destFilename
-  callback = (err) ->
-    asyncHandlers.exitOnError err
-    console.log "Configuration file generated at \"#{destFilename}\""
-  fs.copy src, dest, callback
+  copy src, dest
+    .then "Configuration file generated at \"#{destFilename}\""
+    .catch exitOnError
 
 
 if options['--generate-config']

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -50,7 +50,7 @@ examples = [
 describe 'ConfigurationLoader', ->
   beforeEach ->
     @configurationLoader = new ConfigurationLoader
-    getTmpDir().save @, 'tmpDir'
+    getTmpDir().then (@tmpDir) =>
 
   context 'load', ->
     context 'with a user configuration', ->
@@ -62,13 +62,9 @@ describe 'ConfigurationLoader', ->
           context 'valid', ->
             beforeEach ->
               writeFile @configPath, validContent
-                .then => @configurationLoader.load(@tmpDir).save @, 'result', 'err'
 
-            it 'does not return an error', ->
-              expect(@err).to.not.exist
-
-            it 'returns the default configuration merged with the user configuration', ->
-              expect(@result).to.eql
+            it 'resolves to the default configuration merged with the user configuration', ->
+              expect(@configurationLoader.load(@tmpDir)).to.become
                 allowUnused: []
                 devFilePatterns: ['test/**/*']
                 devScripts: ['lint', 'publish', 'test']
@@ -77,25 +73,14 @@ describe 'ConfigurationLoader', ->
           context 'invalid', ->
             beforeEach ->
               writeFile @configPath, invalidContent
-                .then => @configurationLoader.load(@tmpDir).save @, 'result', 'err'
 
-            it 'returns an error', ->
-              expect(@err).to.exist
-              expect(@err.message).to.include @configPath
-
-            it 'does not return a result', ->
-              expect(@result).to.not.exist
+            it 'rejects with an error that includes the path to the config', ->
+              expect(@configurationLoader.load(@tmpDir)).to.be.rejectedWith(@configPath)
 
 
     context 'without a user configuration', ->
-      beforeEach ->
-        @configurationLoader.load(@tmpDir).save @, 'result', 'err'
-
-      it 'does not return an error', ->
-        expect(@err).to.not.exist
-
       it 'returns the default configuration', ->
-        expect(@result).to.eql
+        expect(@configurationLoader.load(@tmpDir)).to.become
           allowUnused: []
           devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.{coffee,js}']
           devScripts: ['lint', 'publish', 'test']

--- a/src/linter/index.coffee
+++ b/src/linter/index.coffee
@@ -13,10 +13,10 @@ class Linter
 
 
   lint: (dir) ->
-    promises =
-      listedModules: @listedModuleFinder.find dir
-      usedModules: @usedModuleFinder.find dir
-    Promise.props(promises).then @dependencyLinter.lint
+    Promise.resolve [@listedModuleFinder, @usedModuleFinder]
+      .map (finder) -> finder.find dir
+      .then ([listedModules, usedModules]) =>
+        @dependencyLinter.lint {listedModules, usedModules}
 
 
 module.exports = Linter

--- a/src/linter/index.coffee
+++ b/src/linter/index.coffee
@@ -1,8 +1,7 @@
-async = require 'async'
-asyncHandlers = require 'async-handlers'
 DependencyLinter = require './dependency_linter'
 ListedModuleFinder = require './listed_module_finder'
 UsedModuleFinder = require './used_module_finder'
+Promise = require 'bluebird'
 
 
 class Linter
@@ -13,11 +12,11 @@ class Linter
     @usedModuleFinder = new UsedModuleFinder {ignoreFilePatterns}
 
 
-  lint: (dir, done) ->
-    async.parallel {
-      listedModules: (next) => @listedModuleFinder.find dir, next
-      usedModules: (next) => @usedModuleFinder.find dir, next
-    }, asyncHandlers.transform(@dependencyLinter.lint, done)
+  lint: (dir) ->
+    promises =
+      listedModules: @listedModuleFinder.find dir
+      usedModules: @usedModuleFinder.find dir
+    Promise.props(promises).then @dependencyLinter.lint
 
 
 module.exports = Linter

--- a/src/linter/listed_module_finder.coffee
+++ b/src/linter/listed_module_finder.coffee
@@ -1,15 +1,13 @@
 _ = require 'lodash'
-asyncHandlers = require 'async-handlers'
-fsExtra = require 'fs-extra'
 path = require 'path'
+Promise = require 'bluebird'
 
 
 class ListedModuleFinder
 
-  find: (dir, done) =>
+  find: (dir) =>
     filePath = path.join dir, 'package.json'
-    callback = asyncHandlers.transform @extractListedModules, done
-    fsExtra.readJson filePath, callback
+    Promise.try(-> require filePath).then @extractListedModules
 
 
   extractListedModules: (packageJson) ->

--- a/src/linter/listed_module_finder_spec.coffee
+++ b/src/linter/listed_module_finder_spec.coffee
@@ -9,7 +9,7 @@ writeJson = Promise.promisify require('fs-extra').writeJson
 describe 'ListedModuleFinder', ->
   beforeEach ->
     @listedModuleFinder = new ListedModuleFinder
-    getTmpDir().save @, 'tmpDir'
+    getTmpDir().then (@tmpDir) =>
 
   describe 'find', ->
     beforeEach ->
@@ -20,10 +20,8 @@ describe 'ListedModuleFinder', ->
         devDependencies:
           moduleB: '0.0.1'
       writeJson filePath, packageJsonData
-        .then => @listedModuleFinder.find(@tmpDir).save @, 'result', 'err'
 
-    it 'does not return an error', ->
-      expect(@err).to.not.exist
-
-    it 'returns the listed modules', ->
-      expect(@result).to.eql dependencies: ['moduleA'], devDependencies: ['moduleB']
+    it 'resolves to the listed modules', ->
+      expect(@listedModuleFinder.find(@tmpDir)).to.become
+        dependencies: ['moduleA']
+        devDependencies: ['moduleB']

--- a/src/linter/listed_module_finder_spec.coffee
+++ b/src/linter/listed_module_finder_spec.coffee
@@ -1,26 +1,26 @@
-async = require 'async'
-fsExtra = require 'fs-extra'
+getTmpDir = require '../../spec/support/get_tmp_dir'
 path = require 'path'
 ListedModuleFinder = require './listed_module_finder'
-tmp = require 'tmp'
+Promise = require 'bluebird'
+
+writeJson = Promise.promisify require('fs-extra').writeJson
 
 
 describe 'ListedModuleFinder', ->
-  beforeEach (done) ->
-    tmp.dir {unsafeCleanup: true}, (err, @tmpDir) => done err
+  beforeEach ->
+    @listedModuleFinder = new ListedModuleFinder
+    getTmpDir().save @, 'tmpDir'
 
   describe 'find', ->
-    beforeEach (done) ->
+    beforeEach ->
       filePath = path.join @tmpDir, 'package.json'
       packageJsonData =
         dependencies:
           moduleA: '0.0.1'
         devDependencies:
           moduleB: '0.0.1'
-      async.series [
-        (next) -> fsExtra.writeJson filePath, packageJsonData, next
-        (next) => new ListedModuleFinder().find @tmpDir, (@err, @result) => next()
-      ], done
+      writeJson filePath, packageJsonData
+        .then => @listedModuleFinder.find(@tmpDir).save @, 'result', 'err'
 
     it 'does not return an error', ->
       expect(@err).to.not.exist

--- a/src/linter/used_module_finder/executed_module_finder_spec.coffee
+++ b/src/linter/used_module_finder/executed_module_finder_spec.coffee
@@ -8,7 +8,7 @@ outputJson = Promise.promisify require('fs-extra').outputJson
 
 examples = [
   description: 'dependency not installed'
-  expectedError: Error '''
+  expectedError: '''
     The following modules are listed in your `package.json` but are not installed.
       myModule
     All modules need to be installed to properly check for the usage of a module's executables.
@@ -20,7 +20,7 @@ examples = [
   ]
 ,
   description: 'devDependency not installed'
-  expectedError: Error '''
+  expectedError: '''
     The following modules are listed in your `package.json` but are not installed.
       myModule
     All modules need to be installed to properly check for the usage of a module's executables.
@@ -71,7 +71,7 @@ examples = [
 describe 'ExecutedModuleFinder', ->
   beforeEach ->
     @executedModuleFinder = new ExecutedModuleFinder
-    getTmpDir().save @, 'tmpDir'
+    getTmpDir().then (@tmpDir) =>
 
   describe 'find', ->
     examples.forEach ({description, expectedError, expectedResult, packages}) ->
@@ -81,18 +81,10 @@ describe 'ExecutedModuleFinder', ->
             .map ({dir, content}) =>
               filePath = path.join @tmpDir, dir, 'package.json'
               outputJson filePath, content
-            .then => @executedModuleFinder.find(@tmpDir).save @, 'result', 'err'
 
         if expectedError
-          it 'returns the expected error', ->
-            expect(@err).to.eql expectedError
-
-          it 'does not yield a result', ->
-            expect(@result).to.not.exist
-
+          it 'rejects with the expected error', ->
+            expect(@executedModuleFinder.find(@tmpDir)).to.be.rejectedWith expectedError
         else
-          it 'does not yield an error', ->
-            expect(@err).to.not.exist
-
-          it 'returns the expected error', ->
-            expect(@result).to.eql expectedResult
+          it 'resolves with the expected result', ->
+            expect(@executedModuleFinder.find(@tmpDir)).to.become expectedResult

--- a/src/linter/used_module_finder/index.coffee
+++ b/src/linter/used_module_finder/index.coffee
@@ -12,7 +12,8 @@ class UsedModuleFinder
 
 
   find: (dir) =>
-    Promise.all [@requiredModuleFinder.find(dir), @executedModuleFinder.find(dir)]
+    Promise.resolve [@executedModuleFinder, @requiredModuleFinder]
+      .map (finder) -> finder.find dir
       .then @normalizeModules
 
 

--- a/src/linter/used_module_finder/index.coffee
+++ b/src/linter/used_module_finder/index.coffee
@@ -1,7 +1,6 @@
 _ = require 'lodash'
-async = require 'async'
-asyncHandlers = require 'async-handlers'
 ExecutedModuleFinder = require './executed_module_finder'
+Promise = require 'bluebird'
 RequiredModuleFinder = require './required_module_finder'
 
 
@@ -12,11 +11,9 @@ class UsedModuleFinder
     @requiredModuleFinder = new RequiredModuleFinder {ignoreFilePatterns}
 
 
-  find: (dir, done) =>
-    async.parallel [
-      (next) => @requiredModuleFinder.find dir, next
-      (next) => @executedModuleFinder.find dir, next
-    ], asyncHandlers.transform(@normalizeModules, done)
+  find: (dir) =>
+    Promise.all [@requiredModuleFinder.find(dir), @executedModuleFinder.find(dir)]
+      .then @normalizeModules
 
 
   normalizeModules: (modules...) ->

--- a/src/linter/used_module_finder/required_module_finder_spec.coffee
+++ b/src/linter/used_module_finder/required_module_finder_spec.coffee
@@ -1,8 +1,9 @@
-async = require 'async'
-fs = require 'fs'
+getTmpDir = require '../../../spec/support/get_tmp_dir'
 path = require 'path'
+Promise = require 'bluebird'
 RequiredModuleFinder = require './required_module_finder'
-tmp = require 'tmp'
+
+writeFile = Promise.promisify require('fs').writeFile
 
 
 examples = [
@@ -29,17 +30,16 @@ examples = [
 
 
 describe 'RequiredModuleFinder', ->
-  beforeEach (done) ->
-    tmp.dir {unsafeCleanup: true}, (err, @tmpDir) => done err
+  beforeEach ->
+    @requiredModuleFinder = new RequiredModuleFinder {}
+    getTmpDir().save @, 'tmpDir'
 
   describe 'find', ->
     examples.forEach ({content, description, expectedResult, filePath}) ->
       context description, ->
-        beforeEach (done) ->
-          async.series [
-            (next) => fs.writeFile path.join(@tmpDir, filePath), content, next
-            (next) => new RequiredModuleFinder({}).find @tmpDir, (@err, @result) => next()
-          ], done
+        beforeEach ->
+          writeFile path.join(@tmpDir, filePath), content
+            .then => @requiredModuleFinder.find(@tmpDir).save @, 'result', 'err'
 
         it 'does not return an error', ->
           expect(@err).to.not.exist

--- a/src/linter/used_module_finder/required_module_finder_spec.coffee
+++ b/src/linter/used_module_finder/required_module_finder_spec.coffee
@@ -32,17 +32,13 @@ examples = [
 describe 'RequiredModuleFinder', ->
   beforeEach ->
     @requiredModuleFinder = new RequiredModuleFinder {}
-    getTmpDir().save @, 'tmpDir'
+    getTmpDir().then (@tmpDir) =>
 
   describe 'find', ->
     examples.forEach ({content, description, expectedResult, filePath}) ->
       context description, ->
         beforeEach ->
           writeFile path.join(@tmpDir, filePath), content
-            .then => @requiredModuleFinder.find(@tmpDir).save @, 'result', 'err'
 
-        it 'does not return an error', ->
-          expect(@err).to.not.exist
-
-        it 'returns the required module', ->
-          expect(@result).to.eql expectedResult
+        it 'resolves with the required modules', ->
+          expect(@requiredModuleFinder.find(@tmpDir)).to.become expectedResult

--- a/src/run.coffee
+++ b/src/run.coffee
@@ -1,9 +1,8 @@
 _ = require 'lodash'
-async = require 'async'
-asyncHandlers = require 'async-handlers'
 ConfigurationLoader = require './configuration_loader'
-Linter = require './linter'
 DefaultFormatter = require './formatters/default_formatter'
+exitOnError = require './util/exit_on_error'
+Linter = require './linter'
 
 
 hasError = (results) ->
@@ -14,12 +13,10 @@ hasError = (results) ->
 dir = process.cwd()
 
 
-async.waterfall [
-  (next) ->
-    new ConfigurationLoader().load dir, next
-  (config, next) ->
-    new Linter(config).lint dir, next
-  (results, next) ->
+new ConfigurationLoader().load dir
+  .then (config) ->
+    new Linter(config).lint dir
+  .then (results) ->
     new DefaultFormatter({stream: process.stdout}).print results
     process.exit 1 if hasError results
-], asyncHandlers.exitOnError
+  .catch exitOnError

--- a/src/util/exit_on_error.coffee
+++ b/src/util/exit_on_error.coffee
@@ -1,0 +1,10 @@
+colors = require 'colors/safe'
+
+
+exitOnError = (err) ->
+  if err
+    console.error colors.red(err.toString())
+    process.exit 1
+
+
+module.exports = exitOnError

--- a/src/util/prepend_to_error.coffee
+++ b/src/util/prepend_to_error.coffee
@@ -1,0 +1,14 @@
+prependUnlessPresent = (str, prefix) ->
+  if str.indexOf(prefix) is -1
+    [prefix, str].join ': '
+  else
+    str
+
+
+prependToError = (prefix) ->
+  (err) ->
+    err.message = prependUnlessPresent err.message, prefix
+    throw err
+
+
+module.exports = prependToError


### PR DESCRIPTION
@alexdavid @kevgo @alexpeachey

My research into promises

Notes
- really like how it looks. The mixture of async and sync code is far easier and don't have to force sync code into an async interface.
- I don't like bluebird's [promisifyAll](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyallobject-target--object-options---object) which you can apply to modules with a lot of functions because it requires adding a suffix. I like the idea of [promisify-node](https://www.npmjs.com/package/promisify-node) and may end up using that. But just went with the simple for now and just promisified the methods I needed
- Unit testing functions that return promises is definitely a bit weird for me. Initially had
  
  ``` coffee
  functionReturningPromise
    .then ((@result) => ), ((@err) => ) # coffeelint required the extra space after the arrow
  ```
  
  Thus did just extended promises in test with
  
  ``` coffee
  functionReturningPromise
    .save @, 'result', 'err'
  ```
