### PR TITLE
Ignore webpack loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ Any options not set in the configuration file will be given there default value.
 * `ignoreFilePatterns`
   * array of path patterns to match against a filename to determine if it should be ignored (see [minimatch](https://github.com/isaacs/minimatch))
   * default: `['node_modules/**/*']`
+* `stripLoaders`
+  * boolean whether to ignore anything before a `!` in require statements - allows dependency-lint to be used with webpack
+  * default: false

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -26,3 +26,10 @@ module.exports =
   ignoreFilePatterns: [
     'node_modules/**/*'
   ]
+
+  # ignore webpack loaders when evaluating requires
+  # example:
+  #   require('foo!bar!baz')
+  # evaluates to:
+  #   require('baz')
+  stripLoaders: no

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -30,6 +30,6 @@ module.exports =
   # ignore webpack loaders when evaluating requires
   # example:
   #   require('foo!bar!baz')
-  # evaluates to:
+  # is equivalent to:
   #   require('baz')
   stripLoaders: no

--- a/config/default.cson
+++ b/config/default.cson
@@ -28,6 +28,6 @@ ignoreFilePatterns: [
 # ignore webpack loaders when evaluating requires
 # example:
 #   require('foo!bar!baz')
-# evaluates to:
+# is equivalent to:
 #   require('baz')
 stripLoaders: no

--- a/config/default.cson
+++ b/config/default.cson
@@ -24,3 +24,10 @@ devScripts: [
 ignoreFilePatterns: [
   'node_modules/**/*'
 ]
+
+# ignore webpack loaders when evaluating requires
+# example:
+#   require('foo!bar!baz')
+# evaluates to:
+#   require('baz')
+stripLoaders: no

--- a/config/default.js
+++ b/config/default.js
@@ -24,5 +24,12 @@ module.exports = {
   //   (see https://github.com/isaacs/minimatch)
   ignoreFilePatterns: [
     'node_modules/**/*'
-  ]
+  ],
+
+  // ignore webpack loaders when evaluating requires
+  // example:
+  //   require('foo!bar!baz')
+  // evaluates to:
+  //   require('baz')
+  stripLoaders: false
 };

--- a/config/default.js
+++ b/config/default.js
@@ -29,7 +29,7 @@ module.exports = {
   // ignore webpack loaders when evaluating requires
   // example:
   //   require('foo!bar!baz')
-  // evaluates to:
+  // is equivalent to:
   //   require('baz')
   stripLoaders: false
 };

--- a/config/default.json
+++ b/config/default.json
@@ -11,5 +11,6 @@
   ],
   "ignoreFilePatterns":[
     "node_modules/**/*"
-  ]
+  ],
+  "stripLoaders": false
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,6 +25,6 @@ ignoreFilePatterns:
 # ignore webpack loaders when evaluating requires
 # example:
 #   require('foo!bar!baz')
-# evaluates to:
+# is equivalent to:
 #   require('baz')
 stripLoaders: false

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,3 +21,10 @@ devScripts:
 #   (see https://github.com/isaacs/minimatch)
 ignoreFilePatterns:
   - 'node_modules/**/*'
+
+# ignore webpack loaders when evaluating requires
+# example:
+#   require('foo!bar!baz')
+# evaluates to:
+#   require('baz')
+stripLoaders: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,6 @@ ignoreFilePatterns:
 # ignore webpack loaders when evaluating requires
 # example:
 #   require('foo!bar!baz')
-# evaluates to:
+# is equivalent to:
 #   require('baz')
 stripLoaders: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,3 +21,10 @@ devScripts:
 #   (see https://github.com/isaacs/minimatch)
 ignoreFilePatterns:
   - 'node_modules/**/*'
+
+# ignore webpack loaders when evaluating requires
+# example:
+#   require('foo!bar!baz')
+# evaluates to:
+#   require('baz')
+stripLoaders: false

--- a/features/module_with_webpack_loader.feature
+++ b/features/module_with_webpack_loader.feature
@@ -4,9 +4,13 @@ Feature: Required module with a webpack loader
   I want dependency-lint to ignore loaders
 
 
-  Scenario: local dependency with a loader
+  Background:
     Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "my-loader!./other_file"
+    And I have configured "stripLoaders" to be true
+
+
+  Scenario: local dependency with a loader
+    Given I have a file "server.coffee" which requires "my-loader!./other_file"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -15,8 +19,7 @@ Feature: Required module with a webpack loader
 
 
   Scenario: loading a missing-dependency with a loader
-    Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "my-loader!myModule"
+    Given I have a file "server.coffee" which requires "my-loader!myModule"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/module_with_webpack_loader.feature
+++ b/features/module_with_webpack_loader.feature
@@ -1,0 +1,30 @@
+Feature: Required module with a webpack loader
+
+  As a developer using webpack and dependency-lint
+  I want dependency-lint to ignore loaders
+
+
+  Scenario: local dependency with a loader
+    Given I have no dependencies listed
+    And I have a file "server.coffee" which requires "my-loader!./other_file"
+    When I run "dependency-lint"
+    Then I see the output
+      """
+      ✓ 0 errors
+      """
+
+
+  Scenario: loading a missing-dependency with a loader
+    Given I have no dependencies listed
+    And I have a file "server.coffee" which requires "my-loader!myModule"
+    When I run "dependency-lint"
+    Then I see the output
+      """
+      dependencies:
+        ✖ myModule (missing)
+            used in files:
+              server.coffee
+
+      ✖ 1 error
+      """
+    And it exits with a non-zero status

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -1,4 +1,5 @@
 async = require 'async'
+coffee = require 'coffee-script'
 fs = require 'fs'
 fsExtra = require 'fs-extra'
 path = require 'path'
@@ -23,6 +24,13 @@ module.exports = ->
     filePath = path.join @tmpDir, 'dependency-lint.json'
     content = {}
     content[key] = [value]
+    addToJsonFile filePath, content, done
+
+
+  @Given /^I have configured "([^"]*)" to be (.+)$/, (key, value, done) ->
+    filePath = path.join @tmpDir, 'dependency-lint.json'
+    content = {}
+    content[key] = coffee.eval(value)
     addToJsonFile filePath, content, done
 
 

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -1,5 +1,4 @@
 async = require 'async'
-coffee = require 'coffee-script'
 fs = require 'fs'
 fsExtra = require 'fs-extra'
 path = require 'path'
@@ -27,10 +26,10 @@ module.exports = ->
     addToJsonFile filePath, content, done
 
 
-  @Given /^I have configured "([^"]*)" to be (.+)$/, (key, value, done) ->
+  @Given /^I have configured "([^"]*)" to be true$/, (key, done) ->
     filePath = path.join @tmpDir, 'dependency-lint.json'
     content = {}
-    content[key] = coffee.eval(value)
+    content[key] = true
     addToJsonFile filePath, content, done
 
 

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -74,6 +74,7 @@ describe 'ConfigurationLoader', ->
                 devFilePatterns: ['test/**/*']
                 devScripts: ['lint', 'publish', 'test']
                 ignoreFilePatterns: ['node_modules/**/*']
+                stripLoaders: no
 
           context 'invalid', ->
             beforeEach (done) ->
@@ -103,3 +104,4 @@ describe 'ConfigurationLoader', ->
           devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.{coffee,js}']
           devScripts: ['lint', 'publish', 'test']
           ignoreFilePatterns: ['node_modules/**/*']
+          stripLoaders: no

--- a/src/linter/index.coffee
+++ b/src/linter/index.coffee
@@ -7,10 +7,10 @@ UsedModuleFinder = require './used_module_finder'
 
 class Linter
 
-  constructor: ({allowUnused, devFilePatterns, devScripts, ignoreFilePatterns}) ->
+  constructor: ({allowUnused, devFilePatterns, devScripts, ignoreFilePatterns, stripLoaders}) ->
     @dependencyLinter = new DependencyLinter {allowUnused, devFilePatterns, devScripts}
     @listedModuleFinder = new ListedModuleFinder
-    @usedModuleFinder = new UsedModuleFinder {ignoreFilePatterns}
+    @usedModuleFinder = new UsedModuleFinder {ignoreFilePatterns, stripLoaders}
 
 
   lint: (dir, done) ->

--- a/src/linter/used_module_finder/index.coffee
+++ b/src/linter/used_module_finder/index.coffee
@@ -7,9 +7,9 @@ RequiredModuleFinder = require './required_module_finder'
 
 class UsedModuleFinder
 
-  constructor: ({ignoreFilePatterns}) ->
+  constructor: ({ignoreFilePatterns, stripLoaders}) ->
     @executedModuleFinder = new ExecutedModuleFinder
-    @requiredModuleFinder = new RequiredModuleFinder {ignoreFilePatterns}
+    @requiredModuleFinder = new RequiredModuleFinder {ignoreFilePatterns, stripLoaders}
 
 
   find: (dir, done) =>

--- a/src/linter/used_module_finder/module_name_parser.coffee
+++ b/src/linter/used_module_finder/module_name_parser.coffee
@@ -18,6 +18,10 @@ ModuleNameParser =
 
   isRelative: (name) -> name[0] is '.'
 
+  stripLoaders: (name) ->
+    [..., name] = name.split '!'
+    name
+
   stripSubpath: (name) ->
     parts = name.split '/'
     if name[0] is '@'

--- a/src/linter/used_module_finder/module_name_parser_spec.coffee
+++ b/src/linter/used_module_finder/module_name_parser_spec.coffee
@@ -27,6 +27,20 @@ describe 'ModuleNameParser', ->
       expect(ModuleNameParser.isRelative 'other').to.be.false
 
 
+  describe 'stripLoaders', ->
+    it 'returns modules without loaders untouched', ->
+      expect(ModuleNameParser.stripLoaders 'myModule').to.eql 'myModule'
+
+    it 'strips loaders from modules', ->
+      expect(ModuleNameParser.stripLoaders 'my-loader!myModule').to.eql 'myModule'
+
+    it 'strips loaders from relative modules', ->
+      expect(ModuleNameParser.stripLoaders 'my-loader!./myModule').to.eql './myModule'
+
+    it 'strips all loaders', ->
+      expect(ModuleNameParser.stripLoaders 'my-loader!other-loader!myModule').to.eql 'myModule'
+
+
   describe 'stripSubpath', ->
     it 'returns modules without subpaths', ->
       expect(ModuleNameParser.stripSubpath 'myModule').to.eql 'myModule'

--- a/src/linter/used_module_finder/required_module_finder.coffee
+++ b/src/linter/used_module_finder/required_module_finder.coffee
@@ -72,6 +72,7 @@ class RequiredModuleFinder
 
   normalizeModuleNames: ({filePath, moduleNames}) ->
     _.chain moduleNames
+      .map ModuleNameParser.stripLoaders
       .reject ModuleNameParser.isBuiltIn
       .reject ModuleNameParser.isRelative
       .map ModuleNameParser.stripSubpath

--- a/src/linter/used_module_finder/required_module_finder.coffee
+++ b/src/linter/used_module_finder/required_module_finder.coffee
@@ -10,7 +10,7 @@ path = require 'path'
 
 class RequiredModuleFinder
 
-  constructor: ({@ignoreFilePatterns}) ->
+  constructor: ({@ignoreFilePatterns, @stripLoaders}) ->
 
 
   find: (dir, done) ->
@@ -72,7 +72,7 @@ class RequiredModuleFinder
 
   normalizeModuleNames: ({filePath, moduleNames}) ->
     _.chain moduleNames
-      .map ModuleNameParser.stripLoaders
+      .map if @stripLoaders then ModuleNameParser.stripLoaders
       .reject ModuleNameParser.isBuiltIn
       .reject ModuleNameParser.isRelative
       .map ModuleNameParser.stripSubpath


### PR DESCRIPTION
@charlierudolph loaders are common when using webpack and causes dependency-lint to fail. This makes dependency-lint ignore them
