### PR TITLE
add transpilers configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * remove support for configuration files with extensions: cson, coffee, js, json, yaml
   * please convert to dependency-lint.yml
+* remove built in support for coffee-script
+* add `transpilers` configuration option
+* add `filePattern` configuration option
 
 ----
 ### 2.4.0 (2015-12-03)

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Any options not set in the configuration file will be given there default value.
   * default: false
 * `transpilers`
   * array of transpilers to use, each transpiler needs the properties 'extension' and 'module', the module will be required and then the 'compile' property will be called with the file contents and the filename
-  * example: `[{extension: '.coffee', module: 'coffee-script'}]` would call `require('coffee-script').compile(code, {filename: pathToFile});` for each file that ends with `.coffee`
+  * example: `[{extension: '.coffee', module: 'coffee-script'}]` would call `require('coffee-script').compile(code, {filename: pathToFile});` for each file with a `.coffee` extension
   * default: `[]`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Any options not set in the configuration file will be given there default value.
   * boolean whether to ignore anything before a `!` in require statements - allows dependency-lint to be used with webpack
   * default: false
 * `transpilers`
-  * array of transpilers to use, each transpiler needs the properties 'extension' and 'module', the module will be required and then the 'compile' property will be called with the file contents and the filename
+  * array of transpilers with the properties `extension` and `module`. The module will be required and then the `compile` property will be called with the file contents and the filename for each file with that extension
   * example: `[{extension: '.coffee', module: 'coffee-script'}]` would call `require('coffee-script').compile(code, {filename: pathToFile});` for each file with a `.coffee` extension
   * default: `[]`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dependency-lint
 
 ## How it works
 `dependency-lint` compares the node modules listed in your `package.json` and the node modules it determines are used. A node module is used if:
-* it is required in a javascript or coffeescript file
+* it is required in a javascript file (or a file that transpiles to javascript)
 * one of its executables is used in a script in your `package.json`
 
 If you run into an example where `dependency-lint` marks a node module as unused, and you are using it, please create an [issue](https://github.com/charlierudolph/dependency-lint/issues) describing the situation. As a short-term solution, configure `dependency-lint` to allow that node module to be unused.
@@ -40,13 +40,21 @@ Any options not set in the configuration file will be given there default value.
   * Please create an [issue](https://github.com/charlierudolph/dependency-lint/issues) anytime you need to use this
 * `devFilePatterns`
   * array of path patterns to match againt a filename to determine if it is used only for development (see [minimatch](https://github.com/isaacs/minimatch))
-  * default: `['{features,spec,test}/**/*', '**/*_{spec,test}.{coffee,js}']`
+  * default: `['{features,spec,test}/**/*', '**/*_{spec,test}.js']`
 * `devScripts`
   * array of strings or regular expressions to match against a script name in your `package.json` to determine if it is used only for development
   * default: `['lint', 'publish', 'test']`
+* `filePattern`
+  * path pattern to match against a filename to determine if it should be parsed (see https://github.com/isaacs/minimatch)
+  * This is the starting point, devFilePatterns and ignoreFilePatterns should be subsets of this pattern
+  * default: `'**/*.js'`
 * `ignoreFilePatterns`
   * array of path patterns to match against a filename to determine if it should be ignored (see [minimatch](https://github.com/isaacs/minimatch))
   * default: `['node_modules/**/*']`
 * `stripLoaders`
   * boolean whether to ignore anything before a `!` in require statements - allows dependency-lint to be used with webpack
   * default: false
+* `transpilers`
+  * array of transpilers to use, each transpiler needs the properties 'extension' and 'module', the module will be required and then the 'compile' property will be called with the file contents and the filename
+  * example: `[{extension: '.coffee', module: 'coffee-script'}]` would call `require('coffee-script').compile(code, {filename: pathToFile});` for each file that ends with `.coffee`
+  * default: `[]`

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,15 +9,16 @@ devFilePatterns:
   - '{features,spec,test}/**/*'
   - '**/*_{spec,test}.js'
 
-# array of strings or regular expressions to match against a script name in your `package.json`
-# to determine if it is used only for development
+# array of strings or regular expressions to match against a script name
+# in your `package.json` to determine if it is used only for development
 devScripts:
   - lint
   - publish
   - test
 
 # path pattern to match against a filename to determine if it should be parsed.
-# This is the starting point, devFilePatterns and ignoreFilePatterns should be a subsets of this pattern
+# This is the starting point, devFilePatterns and ignoreFilePatterns should be
+# subsets of this pattern
 #   (see https://github.com/isaacs/minimatch)
 filePattern: '**/*.js'
 
@@ -34,8 +35,7 @@ ignoreFilePatterns:
 #   require('baz')
 stripLoaders: false
 
-# array of transpilers to use based on extension
-#   each transpiler needs the properties 'extension' and 'module'
-#   the module will be required and then the 'compile' property will be called
-#   with the file contents and the filename
+# array of transpilers with properties 'extension' and 'module'.
+# The module will be required and then the 'compile' property will be called
+# with the file contents and the filename for each file with that extension
 transpilers: []

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,7 +7,7 @@ allowUnused: []
 #   (see https://github.com/isaacs/minimatch)
 devFilePatterns:
   - '{features,spec,test}/**/*'
-  - '**/*_{spec,test}.{coffee,js}'
+  - '**/*_{spec,test}.js'
 
 # array of strings or regular expressions to match against a script name in your `package.json`
 # to determine if it is used only for development
@@ -15,6 +15,11 @@ devScripts:
   - lint
   - publish
   - test
+
+# path pattern to match against a filename to determine if it should be parsed.
+# This is the starting point, devFilePatterns and ignoreFilePatterns should be a subsets of this pattern
+#   (see https://github.com/isaacs/minimatch)
+filePattern: '**/*.js'
 
 # array of path patterns to match against a filename
 # to determine if it should be ignored
@@ -28,3 +33,9 @@ ignoreFilePatterns:
 # is equivalent to:
 #   require('baz')
 stripLoaders: false
+
+# array of transpilers to use based on extension
+#   each transpiler needs the properties 'extension' and 'module'
+#   the module will be required and then the 'compile' property will be called
+#   with the file contents and the filename
+transpilers: []

--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -19,6 +19,11 @@ devScripts:
   - publish
   - test
 
+# path pattern to match against a filename to determine if it should be parsed.
+# This is the starting point, devFilePatterns and ignoreFilePatterns should be a subsets of this pattern
+#   (see https://github.com/isaacs/minimatch)
+filePattern: '**/*.coffee'
+
 # array of path patterns to match against a filename
 # to determine if it should be ignored
 #   (see https://github.com/isaacs/minimatch)
@@ -32,3 +37,12 @@ ignoreFilePatterns:
 # is equivalent to:
 #   require('baz')
 stripLoaders: false
+
+
+# array of transpilers to use based on extension
+#   each transpiler needs the properties 'extension' and 'module'
+#   the module will be required and then the 'compile' property will be called
+#   with the file contents and the filename
+transpilers:
+  - extension: .coffee
+    module: coffee-script

--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -11,8 +11,8 @@ devFilePatterns:
   - gulpfile.coffee
   - mycha.coffee
 
-# array of strings or regular expressions to match against a script name in your `package.json`
-# to determine if it is used only for development
+# array of strings or regular expressions to match against a script name
+# in your `package.json` to determine if it is used only for development
 devScripts:
   - build
   - lint
@@ -20,7 +20,8 @@ devScripts:
   - test
 
 # path pattern to match against a filename to determine if it should be parsed.
-# This is the starting point, devFilePatterns and ignoreFilePatterns should be a subsets of this pattern
+# This is the starting point, devFilePatterns and ignoreFilePatterns should be
+# subsets of this pattern
 #   (see https://github.com/isaacs/minimatch)
 filePattern: '**/*.coffee'
 
@@ -39,10 +40,9 @@ ignoreFilePatterns:
 stripLoaders: false
 
 
-# array of transpilers to use based on extension
-#   each transpiler needs the properties 'extension' and 'module'
-#   the module will be required and then the 'compile' property will be called
-#   with the file contents and the filename
+# array of transpilers with properties 'extension' and 'module'.
+# The module will be required and then the 'compile' property will be called
+# with the file contents and the filename for each file with that extension
 transpilers:
   - extension: .coffee
     module: coffee-script

--- a/features/coffeescript_compilation_error.feature
+++ b/features/coffeescript_compilation_error.feature
@@ -6,7 +6,7 @@ Feature: Coffeescript compilation error
   Background:
     Given I have configured "filePattern" to be "**/*.coffee"
     And I have configured "transpilers" to contain
-      | extension | module        |
+      | EXTENSION | MODULE        |
       | .coffee   | coffee-script |
 
 

--- a/features/coffeescript_compilation_error.feature
+++ b/features/coffeescript_compilation_error.feature
@@ -3,6 +3,12 @@ Feature: Coffeescript compilation error
   As a developer with an error in my coffeescript file
   I want an appropriate error message
 
+  Background:
+    Given I have configured "filePattern" to be "**/*.coffee"
+    And I have configured "transpilers" to contain
+      | extension | module        |
+      | .coffee   | coffee-script |
+
 
   Scenario: coffeescript compilation error
     Given I have a file "server.coffee" with a coffeescript compilation error

--- a/features/ignore_files.feature
+++ b/features/ignore_files.feature
@@ -7,7 +7,7 @@ Feature: Unused module
   Scenario: dependency
     Given I have no dependencies listed
     And I have configured "ignoreFilePatterns" to contain "examples/**/*"
-    And I have a file "examples/server.coffee" which requires "myModule"
+    And I have a file "examples/server.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -19,7 +19,7 @@ Feature: Unused module
     Given I have no devDependencies listed
     And I have configured "devFilePatterns" to contain "^spec/"
     And I have configured "ignoreFilePatterns" to contain "spec/fixtures/**/*"
-    And I have a file "spec/fixtures/example.coffee" which requires "myModule"
+    And I have a file "spec/fixtures/example.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/module_with_webpack_loader.feature
+++ b/features/module_with_webpack_loader.feature
@@ -10,7 +10,7 @@ Feature: Required module with a webpack loader
 
 
   Scenario: local dependency with a loader
-    Given I have a file "server.coffee" which requires "my-loader!./other_file"
+    Given I have a file "server.js" which requires "my-loader!./other_file"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -19,14 +19,14 @@ Feature: Required module with a webpack loader
 
 
   Scenario: loading a missing-dependency with a loader
-    Given I have a file "server.coffee" which requires "my-loader!myModule"
+    Given I have a file "server.js" which requires "my-loader!myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       dependencies:
         ✖ myModule (missing)
             used in files:
-              server.coffee
+              server.js
 
       ✖ 1 error
       """

--- a/features/required_built_in_module.feature
+++ b/features/required_built_in_module.feature
@@ -6,7 +6,7 @@ Feature: Required module: built in
 
   Scenario: dependency
     Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "http"
+    And I have a file "server.js" which requires "http"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -16,7 +16,7 @@ Feature: Required module: built in
 
   Scenario: devDependency
     Given I have no devDependencies listed
-    And I have a file "server_spec.coffee" which requires "fs"
+    And I have a file "server_spec.js" which requires "fs"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/required_missing_module.feature
+++ b/features/required_missing_module.feature
@@ -6,14 +6,14 @@ Feature: Required module: missing
 
   Scenario: dependency
     Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "myModule"
+    And I have a file "server.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       dependencies:
         ✖ myModule (missing)
             used in files:
-              server.coffee
+              server.js
 
       ✖ 1 error
       """
@@ -22,14 +22,14 @@ Feature: Required module: missing
 
   Scenario: devDependency
     Given I have no devDependencies listed
-    And I have a file "server_spec.coffee" which requires "myModule"
+    And I have a file "server_spec.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       devDependencies:
         ✖ myModule (missing)
             used in files:
-              server_spec.coffee
+              server_spec.js
 
       ✖ 1 error
       """

--- a/features/required_module.feature
+++ b/features/required_module.feature
@@ -10,7 +10,7 @@ Feature: Required module
 
   Scenario: dependency
     Given I have "myModule" listed as a dependency
-    And I have a file "server.coffee" which requires "myModule"
+    And I have a file "server.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -23,7 +23,7 @@ Feature: Required module
 
   Scenario: devDependency
     Given I have "myModule" listed as a devDependency
-    And I have a file "server_spec.coffee" which requires "myModule"
+    And I have a file "server_spec.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/required_module_mislabeled.feature
+++ b/features/required_module_mislabeled.feature
@@ -10,14 +10,14 @@ Feature: Required module: mislabled
 
   Scenario: dependency listed under devDependencies
     Given I have "myModule" listed as a devDependency
-    And I have a file "server.coffee" which requires "myModule"
+    And I have a file "server.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       devDependencies:
         ✖ myModule (should be dependency)
             used in files:
-              server.coffee
+              server.js
 
       ✖ 1 error
       """
@@ -27,7 +27,7 @@ Feature: Required module: mislabled
   Scenario: dependency listed under dependencies and devDependencies
     Given I have "myModule" listed as a dependency
     And I have "myModule" listed as a devDependency
-    And I have a file "server.coffee" which requires "myModule"
+    And I have a file "server.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -37,7 +37,7 @@ Feature: Required module: mislabled
       devDependencies:
         ✖ myModule (should be dependency)
             used in files:
-              server.coffee
+              server.js
 
       ✖ 1 error
       """
@@ -46,14 +46,14 @@ Feature: Required module: mislabled
 
   Scenario: devDependency listed under dependencies
     Given I have "myModule" listed as a dependency
-    And I have a file "server_spec.coffee" which requires "myModule"
+    And I have a file "server_spec.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       dependencies:
         ✖ myModule (should be devDependency)
             used in files:
-              server_spec.coffee
+              server_spec.js
 
       ✖ 1 error
       """
@@ -63,14 +63,14 @@ Feature: Required module: mislabled
   Scenario: devDependency listed under dependencies and devDependencies
     Given I have "myModule" listed as a dependency
     And I have "myModule" listed as a devDependency
-    And I have a file "server_spec.coffee" which requires "myModule"
+    And I have a file "server_spec.js" which requires "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
       dependencies:
         ✖ myModule (should be devDependency)
             used in files:
-              server_spec.coffee
+              server_spec.js
 
       devDependencies:
         ✓ myModule

--- a/features/required_npm.feature
+++ b/features/required_npm.feature
@@ -6,14 +6,14 @@ Feature: Required module: npm
 
   Scenario: dependency not listed
     Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "npm"
+    And I have a file "server.js" which requires "npm"
     When I run "dependency-lint"
     Then I see the output
       """
       dependencies:
         ✖ npm (missing)
           used in files:
-            server.coffee
+            server.js
 
       ✖ 1 error
       """
@@ -23,7 +23,7 @@ Feature: Required module: npm
   Scenario: dependency listed
     Given I have "npm" installed
     And I have "npm" listed as a dependency
-    And I have a file "server.coffee" which requires "npm"
+    And I have a file "server.js" which requires "npm"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -36,14 +36,14 @@ Feature: Required module: npm
 
   Scenario: devDependency not listed
     Given I have no devDependencies listed
-    And I have a file "server_spec.coffee" which requires "npm"
+    And I have a file "server_spec.js" which requires "npm"
     When I run "dependency-lint"
     Then I see the output
       """
       devDependencies:
         ✖ npm (missing)
           used in files:
-            server_spec.coffee
+            server_spec.js
 
       ✖ 1 error
       """
@@ -53,7 +53,7 @@ Feature: Required module: npm
   Scenario: devDependency listed
     Given I have "npm" installed
     And I have "npm" listed as a devDependency
-    And I have a file "server_spec.coffee" which requires "npm"
+    And I have a file "server_spec.js" which requires "npm"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/required_relative_file.feature
+++ b/features/required_relative_file.feature
@@ -6,7 +6,7 @@ Feature: Required module: relative file
 
   Scenario: dependency
     Given I have no dependencies listed
-    And I have a file "server.coffee" which requires "./helper"
+    And I have a file "server.js" which requires "./helper"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -16,7 +16,7 @@ Feature: Required module: relative file
 
   Scenario: devDependency
     Given I have no devDependencies listed
-    And I have a file "server_spec.coffee" which requires "./helper"
+    And I have a file "server_spec.js" which requires "./helper"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/required_scoped_module.feature
+++ b/features/required_scoped_module.feature
@@ -10,7 +10,7 @@ Feature: Required module: scoped
 
   Scenario: dependency
     Given I have "@myOrganization/myModule" listed as a dependency
-    And I have a file "server.coffee" which requires "@myOrganization/myModule"
+    And I have a file "server.js" which requires "@myOrganization/myModule"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -23,7 +23,7 @@ Feature: Required module: scoped
 
   Scenario: devDependency
     Given I have "@myOrganization/myModule" listed as a devDependency
-    And I have a file "server_spec.coffee" which requires "@myOrganization/myModule"
+    And I have a file "server_spec.js" which requires "@myOrganization/myModule"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/required_subpath_of_module.feature
+++ b/features/required_subpath_of_module.feature
@@ -10,7 +10,7 @@ Feature: Required module: subpath
 
   Scenario: path is stripped from module name
     Given I have "myModule" listed as a dependency
-    And I have a file "server.coffee" which requires "myModule/subPath"
+    And I have a file "server.js" which requires "myModule/subPath"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -23,7 +23,7 @@ Feature: Required module: subpath
 
   Scenario: path is stripped from module name
     Given I have "myModule" listed as a devDependency
-    And I have a file "server_spec.coffee" which requires "myModule/subPath"
+    And I have a file "server_spec.js" which requires "myModule/subPath"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/resolved_module.feature
+++ b/features/resolved_module.feature
@@ -10,7 +10,7 @@ Feature: Resolved module
 
   Scenario: dependency
     Given I have "myModule" listed as a dependency
-    And I have a file "server.coffee" which resolves "myModule"
+    And I have a file "server.js" which resolves "myModule"
     When I run "dependency-lint"
     Then I see the output
       """
@@ -23,7 +23,7 @@ Feature: Resolved module
 
   Scenario: devDependency
     Given I have "myModule" listed as a devDependency
-    And I have a file "server_spec.coffee" which resolves "myModule"
+    And I have a file "server_spec.js" which resolves "myModule"
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -34,7 +34,8 @@ module.exports = ->
   @Given /^I have configured "([^"]*)" to contain$/, (key, table, done) ->
     filePath = path.join @tmpDir, 'dependency-lint.yml'
     content = {}
-    content[key] = table.hashes()
+    content[key] = table.hashes().map (obj) ->
+      _.mapKeys obj, (v, k) -> k.toLowerCase()
     addToYmlFile filePath, content, done
 
 

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -1,3 +1,4 @@
+_ = require 'lodash'
 async = require 'async'
 fs = require 'fs'
 fsExtra = require 'fs-extra'
@@ -8,11 +9,15 @@ path = require 'path'
 module.exports = ->
 
   @Given /^I have a file "([^"]*)" which requires "([^"]*)"$/, (file, module, done) ->
-    fsExtra.outputFile path.join(@tmpDir, file), "require '#{module}'", done
+    content = if path.extname(file) is '.coffee'
+      "require '#{module}'"
+    else
+      "require('#{module}')"
+    fsExtra.outputFile path.join(@tmpDir, file), content, done
 
 
   @Given /^I have a file "([^"]*)" which resolves "([^"]*)"$/, (file, module, done) ->
-    fsExtra.outputFile path.join(@tmpDir, file), "require.resolve '#{module}'", done
+    fsExtra.outputFile path.join(@tmpDir, file), "require.resolve('#{module}')", done
 
 
   @Given /^I have a file "([^"]*)" with a coffeescript compilation error$/, (file, done) ->
@@ -23,6 +28,20 @@ module.exports = ->
     filePath = path.join @tmpDir, 'dependency-lint.yml'
     content = {}
     content[key] = [value]
+    addToYmlFile filePath, content, done
+
+
+  @Given /^I have configured "([^"]*)" to contain$/, (key, table, done) ->
+    filePath = path.join @tmpDir, 'dependency-lint.yml'
+    content = {}
+    content[key] = table.hashes()
+    addToYmlFile filePath, content, done
+
+
+  @Given /^I have configured "([^"]*)" to be "([^"]*)"$/, (key, value, done) ->
+    filePath = path.join @tmpDir, 'dependency-lint.yml'
+    content = {}
+    content[key] = value
     addToYmlFile filePath, content, done
 
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/charlierudolph/dependency-lint",
   "devDependencies": {
     "chai": "^3.0.0",
+    "coffee-script": "^1.9.0",
     "coffeelint": "^1.8.1",
     "cucumber": "^0.9.2",
     "gulp": "^3.9.0",
@@ -51,7 +52,6 @@
   "dependencies": {
     "async": "^1.0.0",
     "async-handlers": "^1.2.1",
-    "coffee-script": "^1.9.0",
     "colors": "^1.0.3",
     "detective": "^4.0.0",
     "docopt": "^0.6.0",

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -37,6 +37,7 @@ describe 'ConfigurationLoader', ->
             filePattern: '**/*.js'
             ignoreFilePatterns: ['node_modules/**/*']
             stripLoaders: no
+            transpilers: []
 
       context 'invalid', ->
         beforeEach (done) ->
@@ -64,7 +65,9 @@ describe 'ConfigurationLoader', ->
     it 'returns the default configuration', ->
       expect(@config).to.eql
         allowUnused: []
-        devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.{coffee,js}']
+        devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.js']
         devScripts: ['lint', 'publish', 'test']
+        filePattern: '**/*.js'
         ignoreFilePatterns: ['node_modules/**/*']
         stripLoaders: no
+        transpilers: []

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -34,6 +34,7 @@ describe 'ConfigurationLoader', ->
             allowUnused: []
             devFilePatterns: ['test/**/*']
             devScripts: ['lint', 'publish', 'test']
+            filePattern: '**/*.js'
             ignoreFilePatterns: ['node_modules/**/*']
             stripLoaders: no
 

--- a/src/linter/index.coffee
+++ b/src/linter/index.coffee
@@ -7,10 +7,10 @@ UsedModuleFinder = require './used_module_finder'
 
 class Linter
 
-  constructor: ({allowUnused, devFilePatterns, devScripts, ignoreFilePatterns, stripLoaders}) ->
-    @dependencyLinter = new DependencyLinter {allowUnused, devFilePatterns, devScripts}
+  constructor: (config) ->
+    @dependencyLinter = new DependencyLinter config
     @listedModuleFinder = new ListedModuleFinder
-    @usedModuleFinder = new UsedModuleFinder {ignoreFilePatterns, stripLoaders}
+    @usedModuleFinder = new UsedModuleFinder config
 
 
   lint: (dir, done) ->

--- a/src/linter/used_module_finder/index.coffee
+++ b/src/linter/used_module_finder/index.coffee
@@ -7,9 +7,9 @@ RequiredModuleFinder = require './required_module_finder'
 
 class UsedModuleFinder
 
-  constructor: ({ignoreFilePatterns, stripLoaders}) ->
+  constructor: (config) ->
     @executedModuleFinder = new ExecutedModuleFinder
-    @requiredModuleFinder = new RequiredModuleFinder {ignoreFilePatterns, stripLoaders}
+    @requiredModuleFinder = new RequiredModuleFinder config
 
 
   find: (dir, done) =>

--- a/src/linter/used_module_finder/required_module_finder_spec.coffee
+++ b/src/linter/used_module_finder/required_module_finder_spec.coffee
@@ -10,31 +10,40 @@ examples = [
   description: 'invalid coffeescript'
   expectedError: yes
   filePath: 'server.coffee'
+  filePattern: '**/*.coffee'
+  transpilers: [{extension: '.coffee', module: 'coffee-script'}]
 ,
   content: 'myModule = require "myModule"'
   description: 'coffeescript file requiring a module'
   expectedResult: [name: 'myModule', file: 'server.coffee']
   filePath: 'server.coffee'
+  filePattern: '**/*.coffee'
+  transpilers: [{extension: '.coffee', module: 'coffee-script'}]
 ,
   content: 'myModule = require.resolve "myModule"'
   description: 'coffeescript file resolving a module'
   expectedResult: [name: 'myModule', file: 'server.coffee']
   filePath: 'server.coffee'
+  filePattern: '**/*.coffee'
+  transpilers: [{extension: '.coffee', module: 'coffee-script'}]
 ,
   content: 'var myModule = require("myModule"'
   description: 'invalid javascript'
   expectedError: yes
   filePath: 'server.js'
+  filePattern: '**/*.js'
 ,
   content: 'var myModule = require("myModule");'
   description: 'javascript file requiring a module'
   expectedResult: [name: 'myModule', file: 'server.js']
   filePath: 'server.js'
+  filePattern: '**/*.js'
 ,
   content: 'var myModule = require.resolve("myModule");'
   description: 'javascript file resolving a module'
   expectedResult: [name: 'myModule', file: 'server.js']
   filePath: 'server.js'
+  filePattern: '**/*.js'
 ]
 
 
@@ -43,12 +52,24 @@ describe 'RequiredModuleFinder', ->
     tmp.dir {unsafeCleanup: true}, (err, @tmpDir) => done err
 
   describe 'find', ->
-    examples.forEach ({content, description, expectedError, expectedResult, filePath}) ->
+    examples.forEach (example) ->
+      {
+        content
+        description
+        expectedError
+        expectedResult
+        filePath
+        filePattern
+        transpilers
+      } = example
+
       context description, ->
         beforeEach (done) ->
           async.series [
             (next) => fs.writeFile path.join(@tmpDir, filePath), content, next
-            (next) => new RequiredModuleFinder({}).find @tmpDir, (@err, @result) => next()
+            (next) =>
+              finder = new RequiredModuleFinder {filePattern, transpilers}
+              finder.find @tmpDir, (@err, @result) => next()
           ], done
 
         if expectedError


### PR DESCRIPTION
@kevgo @alexdavid 

This is my attempt at opening up dependency lint to all transpilers.
The default is now simply javascript. I tried it out on `Originate/exoservice-js` (which is livescript) and it worked.

This currently makes assumptions about transpilers exporting a `compile` function which takes in specific arguments but looking at coffeescript, livescript, and pogoscript (something I was exposed to on cucumber-js), they all follow the pattern. I'd also rather not make it more complicated unless someone want to use some other transpiler.
