### PR TITLE
remove comments from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dependency-lint
 If you run into an example where `dependency-lint` marks a node module as unused, and you are using it, please create an [issue](https://github.com/charlierudolph/dependency-lint/issues) describing the situation. As a short-term solution, configure `dependency-lint` to allow that node module to be unused.
 
 ## Configuration
-The default configuration can be found [here](config/default.yml).
+Please see [here](docs/configuration.md) for an explanation of all the options.
 Custom configuration should be placed at `dependency-lint.yml` in your project directory.
 You can create a configuration file by running
 ```

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,50 +1,19 @@
-# array of strings or regular expressions to match against a module name
-# to determine if it is allowed to be unused
-#
-# Please create an issue at
-# https://github.com/charlierudolph/dependency-lint/issues
-# anytime you need to use this
 allowUnused: []
 
-# array of path patterns to match againt a filename
-# to determine if it is used only for development
-#   (see https://github.com/isaacs/minimatch)
 devFilePatterns:
   - '{features,spec,test}/**/*'
   - '**/*_{spec,test}.js'
 
-# array of strings or regular expressions to match against a script name
-# in your `package.json` to determine if it is used only for development
 devScripts:
   - lint
   - publish
   - test
 
-# path pattern to match against a filename to determine if it should be parsed.
-#   (see https://github.com/isaacs/minimatch)
-#
-# This is the starting point, devFilePatterns and ignoreFilePatterns should be
-# subsets of this pattern
 filePattern: '**/*.js'
 
-# array of path patterns to match against a filename
-# to determine if it should be ignored
-#   (see https://github.com/isaacs/minimatch)
 ignoreFilePatterns:
   - 'node_modules/**/*'
 
-# boolean whether to ignore anything before a `!` in require statements
-#
-# Useful for:
-#   webpack loaders - https://webpack.github.io/docs/loaders.html
-#   RequireJS loader plugins - http://requirejs.org/docs/plugins.html
 stripLoaders: false
 
-# array of transpilers with properties 'extension' and 'module'.
-#
-# The module will be required and then the 'compile' property will be called
-# with the file contents and the file path for each file with that extension
-#
-#   require(<module>).compile(fileContents, {filename: filePath});
-#
 transpilers: []

--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -1,48 +1,25 @@
-# array of strings or regular expressions to match against a module name
-# to determine if it is allowed to be unused
 allowUnused: []
 
-# array of path patterns to match againt a filename
-# to determine if it is used only for development
-#   (see https://github.com/isaacs/minimatch)
 devFilePatterns:
   - '{features,spec}/**/*'
   - '**/*_spec.coffee'
   - gulpfile.coffee
   - mycha.coffee
 
-# array of strings or regular expressions to match against a script name
-# in your `package.json` to determine if it is used only for development
 devScripts:
   - build
   - lint
   - publish
   - test
 
-# path pattern to match against a filename to determine if it should be parsed.
-# This is the starting point, devFilePatterns and ignoreFilePatterns should be
-# subsets of this pattern
-#   (see https://github.com/isaacs/minimatch)
 filePattern: '**/*.coffee'
 
-# array of path patterns to match against a filename
-# to determine if it should be ignored
-#   (see https://github.com/isaacs/minimatch)
 ignoreFilePatterns:
   - 'dist/**/*'
   - 'node_modules/**/*'
 
-# ignore webpack loaders when evaluating requires
-# example:
-#   require('foo!bar!baz')
-# is equivalent to:
-#   require('baz')
 stripLoaders: false
 
-
-# array of transpilers with properties 'extension' and 'module'.
-# The module will be required and then the 'compile' property will be called
-# with the file contents and the filename for each file with that extension
 transpilers:
   - extension: .coffee
     module: coffee-script

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,12 +76,10 @@ stripLoaders: true
 
 ---
 ### transpilers
-Maps file extension to a compile function.
-Should be an array of objects with properties `extension` and `module`
+Transpiles code to javascript based on its extension.
+Each transpiler should specify an `extension` and a `module`.
 
-The `module` will be required and then the `compile` property will be called
-with the file contents and the file path for each file with that `extension`
-
+For each file with `extension`, the following will be called:
 ```js
 require(module).compile(fileContents, {filename: filePath});
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,6 @@
 # Configuration Options
 
+The default appears at the end of each
 
 ### allowUnused
 array of strings or regular expressions to match against a module name
@@ -13,6 +14,7 @@ default:
 allowUnused: []
 ```
 
+---
 ### devFilePatterns
 array of path patterns to match against a filename to determine if it is used
 only for development (see [minimatch](https://github.com/isaacs/minimatch))
@@ -24,6 +26,7 @@ devFilePatterns:
   - '**/*_{spec,test}.js'
 ```
 
+---
 ### devScripts
 array of strings or regular expressions to match against a script name
 in your `package.json` to determine if it is used only for development
@@ -36,11 +39,12 @@ devScripts:
   - test
 ```
 
+---
 ### filePattern
 path pattern to match against a filename to determine if it should be parsed
 (see [minimatch](https://github.com/isaacs/minimatch))
 
-This is the starting point, devFilePatterns and ignoreFilePatterns should be
+This is the starting point, `devFilePatterns` and `ignoreFilePatterns` should be
 subsets of this pattern
 
 default:
@@ -48,6 +52,7 @@ default:
 filePattern: '**/*.js'
 ```
 
+---
 ### ignoreFilePatterns
 array of path patterns to match against a filename to determine if it should be
 ignored (see [minimatch](https://github.com/isaacs/minimatch))
@@ -58,6 +63,7 @@ ignoreFilePatterns:
   - 'node_modules/**/*'
 ```
 
+---
 ### stripLoaders
 boolean whether to ignore anything before a `!` in require statements
 
@@ -69,12 +75,14 @@ default:
 stripLoaders: false
 ```
 
+---
 ### transpilers
-array of objects with properties 'extension' and 'module'.
+array of objects with properties `extension` and `module`
 
-The module will be required and then the 'compile' property will be called
-with the file contents and the file path for each file with that extension
+The `module` will be required and then the `compile` property will be called
+with the file contents and the file path for each file with that `extension`
 
+Example:
 ```js
 require(module).compile(fileContents, {filename: filePath});
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,8 @@ with the file contents and the file path for each file with that `extension`
 require(module).compile(fileContents, {filename: filePath});
 ```
 
+If the transpiler you're using doesn't follow this pattern, please open an [issue](https://github.com/charlierudolph/dependency-lint/issues)
+
 Example:
 ```yml
 transpilers:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,85 @@
+# Configuration Options
+
+
+### allowUnused
+array of strings or regular expressions to match against a module name
+to determine if it is allowed to be unused
+
+Please create an [issue](https://github.com/charlierudolph/dependency-lint/issues)
+anytime you need to use this
+
+default:
+```yml
+allowUnused: []
+```
+
+### devFilePatterns
+array of path patterns to match against a filename to determine if it is used
+only for development (see [minimatch](https://github.com/isaacs/minimatch))
+
+default:
+```yml
+devFilePatterns:
+  - '{features,spec,test}/**/*'
+  - '**/*_{spec,test}.js'
+```
+
+### devScripts
+array of strings or regular expressions to match against a script name
+in your `package.json` to determine if it is used only for development
+
+default:
+```yml
+devScripts:
+  - lint
+  - publish
+  - test
+```
+
+### filePattern
+path pattern to match against a filename to determine if it should be parsed
+(see [minimatch](https://github.com/isaacs/minimatch))
+
+This is the starting point, devFilePatterns and ignoreFilePatterns should be
+subsets of this pattern
+
+default:
+```yml
+filePattern: '**/*.js'
+```
+
+### ignoreFilePatterns
+array of path patterns to match against a filename to determine if it should be
+ignored (see [minimatch](https://github.com/isaacs/minimatch))
+
+default:
+```yml
+ignoreFilePatterns:
+  - 'node_modules/**/*'
+```
+
+### stripLoaders
+boolean whether to ignore anything before a `!` in require statements
+
+Useful for [webpack loaders](https://webpack.github.io/docs/loaders.html) and
+[RequireJS loader plugins](http://requirejs.org/docs/plugins.html)
+
+default:
+```yml
+stripLoaders: false
+```
+
+### transpilers
+array of objects with properties 'extension' and 'module'.
+
+The module will be required and then the 'compile' property will be called
+with the file contents and the file path for each file with that extension
+
+```js
+require(module).compile(fileContents, {filename: filePath});
+```
+
+default:
+```yml
+transpilers: []
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,7 @@
 
 See the default config [here](../config/default.yml)
 
+---
 ### allowUnused
 List of modules that are allowed to be unused.
 Passed to `string.match`
@@ -12,7 +13,7 @@ anytime you need to use this
 Example:
 ```yml
 allowUnused:
-  - gulp
+  - mocha
 ```
 
 ---
@@ -88,6 +89,6 @@ require(module).compile(fileContents, {filename: filePath});
 Example:
 ```yml
 transpilers:
-  extension: 'coffee'
-  module: 'coffee-script'
+  - extension: .coffee
+    module: coffee-script
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,4 @@
-# Configuration Options
-
-The default appears at the end of each
+# Configuration
 
 ### allowUnused
 array of strings or regular expressions to match against a module name

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ array of objects with properties `extension` and `module`
 The `module` will be required and then the `compile` property will be called
 with the file contents and the file path for each file with that `extension`
 
-Example:
+example:
 ```js
 require(module).compile(fileContents, {filename: filePath});
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,49 +1,49 @@
 # Configuration
 
+See the default config [here](../config/default.yml)
+
 ### allowUnused
-array of strings or regular expressions to match against a module name
-to determine if it is allowed to be unused
+List of modules that are allowed to be unused.
+Passed to `string.match`
 
 Please create an [issue](https://github.com/charlierudolph/dependency-lint/issues)
 anytime you need to use this
 
-default:
+Example:
 ```yml
-allowUnused: []
+allowUnused:
+  - gulp
 ```
 
 ---
 ### devFilePatterns
-array of path patterns to match against a filename to determine if it is used
-only for development (see [minimatch](https://github.com/isaacs/minimatch))
+Files used only for development.
+Uses [minimatch](https://github.com/isaacs/minimatch)
 
-default:
+Example:
 ```yml
 devFilePatterns:
-  - '{features,spec,test}/**/*'
-  - '**/*_{spec,test}.js'
+  - '**/*_test.js'
 ```
 
 ---
 ### devScripts
-array of strings or regular expressions to match against a script name
-in your `package.json` to determine if it is used only for development
+List of scripts in your `package.json` used only for development.
+Passed to `string.match`
 
-default:
+Example:
 ```yml
 devScripts:
-  - lint
-  - publish
   - test
 ```
 
 ---
 ### filePattern
-path pattern to match against a filename to determine if it should be parsed
-(see [minimatch](https://github.com/isaacs/minimatch))
+All source files.
+Uses [minimatch](https://github.com/isaacs/minimatch)
 
 This is the starting point, `devFilePatterns` and `ignoreFilePatterns` should be
-subsets of this pattern
+subsets of this pattern.
 
 default:
 ```yml
@@ -52,40 +52,42 @@ filePattern: '**/*.js'
 
 ---
 ### ignoreFilePatterns
-array of path patterns to match against a filename to determine if it should be
-ignored (see [minimatch](https://github.com/isaacs/minimatch))
+Files that should be ignored.
+Uses [minimatch](https://github.com/isaacs/minimatch)
 
-default:
+Example:
 ```yml
 ignoreFilePatterns:
-  - 'node_modules/**/*'
+  - 'dist/**/*'
 ```
 
 ---
 ### stripLoaders
-boolean whether to ignore anything before a `!` in require statements
+Whether or not to ignore anything before a `!` in require statements
 
 Useful for [webpack loaders](https://webpack.github.io/docs/loaders.html) and
 [RequireJS loader plugins](http://requirejs.org/docs/plugins.html)
 
-default:
+Example:
 ```yml
-stripLoaders: false
+stripLoaders: true
 ```
 
 ---
 ### transpilers
-array of objects with properties `extension` and `module`
+Maps file extension to a compile function.
+Should be an array of objects with properties `extension` and `module`
 
 The `module` will be required and then the `compile` property will be called
 with the file contents and the file path for each file with that `extension`
 
-example:
 ```js
 require(module).compile(fileContents, {filename: filePath});
 ```
 
-default:
+Example:
 ```yml
-transpilers: []
+transpilers:
+  extension: 'coffee'
+  module: 'coffee-script'
 ```

--- a/features/generate_config.feature
+++ b/features/generate_config.feature
@@ -7,6 +7,11 @@ Feature: Generating config
   Scenario: generate config
     When I run "dependency-lint --generate-config"
     Then now I have the file "dependency-lint.yml" with the default config
+    And "dependency-lint.yml" contains
+      """
+      # See https://github.com/charlierudolph/dependency-lint/blob/v{{version}}/docs/configuration.md
+      # for a detailed explanation of the options
+      """
     When I run "dependency-lint"
     Then I see the output
       """

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -6,6 +6,7 @@ path = require 'path'
 {addToJsonFile, addToYmlFile} = require '../support/file_helpers'
 yaml = require 'js-yaml'
 
+
 module.exports = ->
 
   @Given /^I have a file "([^"]*)" which requires "([^"]*)"$/, (file, module, done) ->

--- a/features/step_definitions/file_steps.coffee
+++ b/features/step_definitions/file_steps.coffee
@@ -4,7 +4,7 @@ fs = require 'fs'
 fsExtra = require 'fs-extra'
 path = require 'path'
 {addToJsonFile, addToYmlFile} = require '../support/file_helpers'
-
+yaml = require 'js-yaml'
 
 module.exports = ->
 
@@ -102,13 +102,24 @@ module.exports = ->
 
   @Then /^now I have the file "([^"]*)" with the default config$/, (filename, done) ->
     filePaths = [
-      path.join __dirname, '..', '..', 'config', "default#{path.extname filename}"
+      path.join __dirname, '..', '..', 'config', "default.yml"
       path.join @tmpDir, filename
     ]
     iterator = (filePath, next) ->
       fs.readFile filePath, encoding: 'utf8', next
     callback = (err, [defaultConfigContent, fileContent] = []) ->
       if err then return done err
-      expect(fileContent).to.eql defaultConfigContent
+      defaultConfig = yaml.load defaultConfigContent
+      userConfig = yaml.load fileContent
+      expect(userConfig).to.eql defaultConfig
       done()
     async.map filePaths, iterator, callback
+
+
+  @Then /^"([^"]*)" contains$/, (filename, content, done) ->
+    filePath = path.join @tmpDir, filename
+    fs.readFile filePath, encoding: 'utf8', (err, fileContent) ->
+      version = require('../../package.json').version
+      content = content.replace '{{version}}', version
+      expect(fileContent).to.contain content
+      done()

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -29,13 +29,11 @@ generateConfig = ->
   async.waterfall [
     (next) -> fs.readFile src, 'utf8', next
     (contents, next) ->
-      link = "https://github.com/charlierudolph/dependency-lint/" +
-        "blob/v#{packageJson.version}/docs/configuration.md"
-      contents = """
-        # See #{link}
+      comment = """
+        # See #{packageJson.homepage}/blob/v#{packageJson.version}/docs/configuration.md
         # for a detailed explanation of the options
-        """ + "\n" + contents
-      fs.writeFile dest, contents, next
+        """
+      fs.writeFile dest, comment + '\n\n' + contents, next
   ], callback
 
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -2,8 +2,8 @@ async = require 'async'
 asyncHandlers = require 'async-handlers'
 {docopt} = require 'docopt'
 fs = require 'fs-extra'
-path = require 'path'
 packageJson = require '../package.json'
+path = require 'path'
 
 
 usage = '''
@@ -28,12 +28,14 @@ generateConfig = ->
     console.log 'Configuration file generated at "dependency-lint.yml"'
   async.waterfall [
     (next) -> fs.readFile src, 'utf8', next
-    (contents, next) ->
-      comment = """
+    (defaultConfig, next) ->
+      fileContents = """
         # See #{packageJson.homepage}/blob/v#{packageJson.version}/docs/configuration.md
         # for a detailed explanation of the options
+
+        #{defaultConfig}
         """
-      fs.writeFile dest, comment + '\n\n' + contents, next
+      fs.writeFile dest, fileContents, next
   ], callback
 
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -1,17 +1,23 @@
+async = require 'async'
 asyncHandlers = require 'async-handlers'
 {docopt} = require 'docopt'
 fs = require 'fs-extra'
 path = require 'path'
+packageJson = require '../package.json'
 
 
-options = docopt '''
+usage = '''
   Usage:
     dependency-lint [--generate-config]
 
   Options:
     -h, --help           Show this screen
     --generate-config    Generate a configuration file
+    -v, --version        Show version
   '''
+
+
+options = docopt usage, version: packageJson.version
 
 
 generateConfig = ->
@@ -20,7 +26,17 @@ generateConfig = ->
   callback = (err) ->
     asyncHandlers.exitOnError err
     console.log 'Configuration file generated at "dependency-lint.yml"'
-  fs.copy src, dest, callback
+  async.waterfall [
+    (next) -> fs.readFile src, 'utf8', next
+    (contents, next) ->
+      link = "https://github.com/charlierudolph/dependency-lint/" +
+        "blob/v#{packageJson.version}/docs/configuration.md"
+      contents = """
+        # See #{link}
+        # for a detailed explanation of the options
+        """ + "\n" + contents
+      fs.writeFile dest, contents, next
+  ], callback
 
 
 if options['--generate-config']


### PR DESCRIPTION
@kevgo

What do you think of this? Strip yaml of comments and provide a link to the doc explaining them. The link will be based on the version when you generated the config.
