### PR TITLE
Allow test files with dashes

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2,7 +2,7 @@ allowUnused: []
 
 devFilePatterns:
   - '{features,spec,test}/**/*'
-  - '**/*_{spec,test}.js'
+  - '**/*{.,_,-}{spec,test}.js'
 
 devScripts:
   - lint

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -65,7 +65,7 @@ describe 'ConfigurationLoader', ->
     it 'returns the default configuration', ->
       expect(@config).to.eql
         allowUnused: []
-        devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.js']
+        devFilePatterns: ['{features,spec,test}/**/*', '**/*{.,_,-}{spec,test}.js']
         devScripts: ['lint', 'publish', 'test']
         filePattern: '**/*.js'
         ignoreFilePatterns: ['node_modules/**/*']


### PR DESCRIPTION
Add support for test files named like this: `foo-spec.js`.

@charlierudolph @alexdavid 
