### PR TITLE
Ignore unused dependency-lint

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
-allowUnused: []
+allowUnused:
+  - dependency-lint
 
 devFilePatterns:
   - '{features,spec,test}/**/*'

--- a/src/configuration_loader/index_spec.coffee
+++ b/src/configuration_loader/index_spec.coffee
@@ -31,7 +31,7 @@ describe 'ConfigurationLoader', ->
 
         it 'returns the default configuration merged with the user configuration', ->
           expect(@result).to.eql
-            allowUnused: []
+            allowUnused: ['dependency-lint']
             devFilePatterns: ['test/**/*']
             devScripts: ['lint', 'publish', 'test']
             filePattern: '**/*.js'
@@ -64,7 +64,7 @@ describe 'ConfigurationLoader', ->
 
     it 'returns the default configuration', ->
       expect(@config).to.eql
-        allowUnused: []
+        allowUnused: ['dependency-lint']
         devFilePatterns: ['{features,spec,test}/**/*', '**/*_{spec,test}.js']
         devScripts: ['lint', 'publish', 'test']
         filePattern: '**/*.js'


### PR DESCRIPTION
Dependency-lint should always assume it is used.

resolves #21 

@charlierudolph @alexdavid 
