### PR TITLE
[super minor] fix error when duplicate devDep has higher version

### DIFF
--- a/src/linter/installed_module_validator.coffee
+++ b/src/linter/installed_module_validator.coffee
@@ -14,7 +14,7 @@ readJson = Promise.promisify fsExtra.readJson
 class InstalledModuleValidater
 
   validate: coroutine ({dir, packageJson}) ->
-    modules = _.assign {}, packageJson.dependencies, packageJson.devDependencies
+    modules = _.assign {}, packageJson.devDependencies, packageJson.dependencies
     issues = []
     yield Promise.all _.map modules, coroutine (version, name) =>
       return unless semver.validRange version

--- a/src/linter/installed_module_validator_spec.coffee
+++ b/src/linter/installed_module_validator_spec.coffee
@@ -76,6 +76,17 @@ examples = [
   packageJson:
     devDependencies:
       myModule: 'git+ssh://git@host:myOrganization/myModule.git#1.0.0"'
+,
+  description: 'validate the version specified in dependencies'
+  installedModules: [
+    name: 'myModule'
+    version: '0.9.1'
+  ]
+  packageJson:
+    dependencies:
+      myModule: '0.9.1'
+    devDependencies:
+      myModule: '1.0.0'
 ]
 
 


### PR DESCRIPTION
Given the following situation:
```
dependencies: {
  "myModule": "0.9.1"
},
devDependencies: {
  "myModule": "1.0.0"
}
```
the linter will check for installed version 1.0.0, even though `npm` resolves duplicate modules in favor of the non-dev dependency version. This error incorrectly suggests that the wrong version is installed (i.e. 0.9.1), when it should instead suggest that MyModule be moved to dependencies.

This scenario is a  bit contrived and a result of user error, but caused me a moment of confusion with the utility since the "wrong version" error fails fast and doesn't suggest a duplicate. Took me a minute to spot the duplicate because the "wrong version" was the correct version listed in dependencies. :)